### PR TITLE
Modifications (mainly multimethod) to run as LUTE task

### DIFF
--- a/sd2qwp1.py
+++ b/sd2qwp1.py
@@ -104,6 +104,8 @@ def main():
     parser.add_argument('--output', type=str, default='', help="""str (eg: '/path/to/') - destination for the folder containing output PND and HDF5 files""")
     parser.add_argument('--output_h5', type=str, default='', help="""str (eg: 'run0005_sd2qwp1.hdf5') - name of the output h5 file""")
     parser.add_argument('--input', type=str, default='', help="""str (eg: '/path/to/') - path to input smalldata h5 file""")
+    parser.add_argument('--peakfit', type=str, default='', 
+                        help="""Dummy argument for compatibility with smalldata_to_Tval_multimethod.py. Not used in this script.""")
 
     args=parser.parse_args()
     run = args.run

--- a/smalldata_to_Tval_multimethod.py
+++ b/smalldata_to_Tval_multimethod.py
@@ -88,7 +88,8 @@ def two_peak_fit(x_in, y_in, temp=0, plot=False, verbose=False, model_type='gaus
         plt.plot(x, y_corr, label="Corrected")
         plt.plot(x, dy, '--', label="1st Derivative")
         plt.plot(x, d2y, ':', label="2nd Derivative")
-        plt.legend(); plt.title("Derivative Check"); plt.grid(True); plt.show()
+        plt.legend(); plt.title("Derivative Check"); plt.grid(True); # plt.show()
+        plt.savefig("{}/run{:04d}_Derivative_Check.png".format(output_dir,run), dpi=100)
 
     # Choose model type
     if model_type.lower() == 'voigt':
@@ -126,7 +127,7 @@ def two_peak_fit(x_in, y_in, temp=0, plot=False, verbose=False, model_type='gaus
         result.plot_fit()
         plt.grid(True)
         plt.title(f"{model_type.title()} Two-Peak Fit @ Temp {temp}K")
-        plt.show()
+        plt.savefig("{}/run{:04d}_Two-Peak_Fit_Temp_{}K.png".format(output_dir,run,temp), dpi=100)
 
         comps = result.eval_components(x=x)
         plt.plot(x, comps['g1_'], label='Peak 1')
@@ -134,7 +135,7 @@ def two_peak_fit(x_in, y_in, temp=0, plot=False, verbose=False, model_type='gaus
         plt.legend()
         plt.grid(True)
         plt.title("Individual Peak Components")
-        plt.show()
+        plt.savefig("{}/run{:04d}_Individual_Peak_Components.png".format(output_dir,run), dpi=100)
 
     # Extract peak positions and compute delta
     c1 = result.params['g1_center'].value


### PR DESCRIPTION
This version can successfully run as a standalone task using my LUTE (branch: tjump, commit: ba21c86 or 414a2cb) via command line like follows:

`lute/launch_scripts/submit_slurm.sh -t TJumpAnalyzer -c lute/config/solvent_scatter_example.yaml -e mfx101080524 -r 151 --account=lcls:mfx101080524 --partition=milano`

Changes I made include:
- Fixed typo/incomplete code that prevented `smalldata_to_Tval_multimethod.py` from running standalone.
- I/O: Make both scripts have consistent I/O for LUTE task, including changing argparse and figure saving names.
- Disabled interactive plotting and forwarding to run as a LUTE task.
- Non-trivial change to exponential curve fit (line 471-507) in `smalldata_to_Tval_multimethod.py`:
    - Previous initialization appears to have parameters `C` and `D` swapped, which leads to numerical instability / failed fit for run146 for example. The new `A/k/C/D` init values would roughly correspond to `p0=[60, 1, 1.92, 280]`. The fitted value and curve looks reasonable (see eLog summary run146 as an example).
    - Despite the new init values, the exponential fit is still not very robust. Instead of manually tweaking init values in the script every time, I implemented a fallback to linear regression as used in `sd2qwp1.py` for production stability.
- In the final summary plot (scatter and exponential/linear fit) of water peak vs temperature fit, the original code didn’t reverse `x/y` as desired for visualization purposes. This is fixed to generate the same kind of summary plot as in `sd2qwp1.py`.